### PR TITLE
sequential electron-rebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test-app-full": "npm run test-app -- -f '#full'",
     "test-unit": "mocha test/unit",
     "eslint": "eslint --ext .js --ext .jsx .",
-    "postinstall": "if [ \"$NODE_ENV\" != \"production\" ] ; then electron-rebuild; fi"
+    "postinstall": "if [ \"$NODE_ENV\" != \"production\" ] ; then electron-rebuild -s; fi"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
so we can prevent this

```
 Rebuild Failed
An unhandled error occurred inside electron-rebuild
gyp info it worked if it ends with ok
gyp info using node-gyp@3.6.2
gyp info using node@8.1.2 | linux | x64
gyp ERR! configure error 
gyp ERR! stack Error: Command failed: /home/rof/.pyenv/shims/python2 -c import platform; print(platform.python_version());
gyp ERR! stack pyenv: cannot rehash: /home/rof/.pyenv/shims/.pyenv-shim exists
```